### PR TITLE
Fix account deletion to actually delete the Firebase Auth user

### DIFF
--- a/src/components/settings/DeleteAccountSettings.tsx
+++ b/src/components/settings/DeleteAccountSettings.tsx
@@ -1,13 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { auth, db } from "@/lib/firebase";
-import { signOut, onAuthStateChanged, User } from "firebase/auth";
+import {
+  signOut,
+  onAuthStateChanged,
+  User,
+  deleteUser,
+  reauthenticateWithCredential,
+  EmailAuthProvider,
+} from "firebase/auth";
 import { collection, query, where, getDocs, deleteDoc, doc } from "firebase/firestore";
 import { heavyHaptic } from "@/utils/ios/haptics";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -22,20 +29,27 @@ const DeleteAccountSettings = () => {
   const [user, setUser] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   useEffect(() => {
     if (!auth) return;
 
-    // Initial check
     setUser(auth.currentUser);
 
-    // Listen for auth changes
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
     });
 
     return () => unsubscribe();
   }, []);
+
+  const handleOpenDialog = () => {
+    setPassword("");
+    setError(null);
+    setMessage(null);
+    setIsDeleteDialogOpen(true);
+  };
 
   const handleDeleteAccount = async () => {
     if (!auth || !db) return;
@@ -47,34 +61,40 @@ const DeleteAccountSettings = () => {
       heavyHaptic();
 
       const currentUser = auth.currentUser;
-      if (!currentUser) {
+      if (!currentUser || !currentUser.email) {
         setError("No user found to delete.");
         setDeleteLoading(false);
         return;
       }
 
-      // 1. Delete user data from Firestore
+      // 1. Re-authenticate to satisfy Firebase's recent-login requirement
+      //    (deleteUser is a sensitive operation and will fail without this)
+      const credential = EmailAuthProvider.credential(currentUser.email, password);
+      await reauthenticateWithCredential(currentUser, credential);
+
+      // 2. Delete user's places from Firestore
       try {
         const q = query(
           collection(db, 'places'),
           where('user_id', '==', currentUser.uid)
         );
         const snapshot = await getDocs(q);
-        const deletePromises = snapshot.docs.map(placeDoc => deleteDoc(doc(db, 'places', placeDoc.id)));
+        const deletePromises = snapshot.docs.map(placeDoc =>
+          deleteDoc(doc(db, 'places', placeDoc.id))
+        );
         await Promise.all(deletePromises);
         console.log("[Settings] Deleted user places from Firestore");
       } catch (dataError: any) {
         console.warn("[Settings] Could not delete user records:", dataError.message);
+        // Continue — account deletion should still proceed even if Firestore cleanup fails
       }
 
-      // 2. Sign out the user
-      // Note: Actual Firebase account deletion usually requires re-authentication.
-      // For now, we sign out and clear local data.
-      await signOut(auth);
+      // 3. Delete the Firebase Auth account
+      await deleteUser(currentUser);
 
-      // 3. Clear all local storage data
+      // 4. Clear all local storage data
       const keysToRemove = [
-        'recommendations', // Updated key
+        'recommendations',
         'travelist-recommendations',
         'travelist-routes',
         'travelist-collections',
@@ -86,10 +106,16 @@ const DeleteAccountSettings = () => {
 
       setUser(null);
       setIsDeleteDialogOpen(false);
-      setMessage("Account data deleted successfully. Your account has been signed out.");
+      setMessage("Your account has been permanently deleted.");
 
     } catch (err: any) {
-      setError(err?.message ?? "Could not delete account");
+      if (err?.code === 'auth/wrong-password' || err?.code === 'auth/invalid-credential') {
+        setError("Incorrect password. Please try again.");
+      } else if (err?.code === 'auth/too-many-requests') {
+        setError("Too many attempts. Please wait a moment and try again.");
+      } else {
+        setError(err?.message ?? "Could not delete account. Please try again.");
+      }
     } finally {
       setDeleteLoading(false);
     }
@@ -113,14 +139,14 @@ const DeleteAccountSettings = () => {
 
         <Button
           variant="outline"
-          onClick={() => setIsDeleteDialogOpen(true)}
+          onClick={handleOpenDialog}
           className="border-destructive text-destructive hover:bg-destructive/10"
         >
           Delete My Account
         </Button>
 
         {message && <p className="text-xs text-green-600">{message}</p>}
-        {error && <p className="text-xs text-destructive">{error}</p>}
+        {error && !isDeleteDialogOpen && <p className="text-xs text-destructive">{error}</p>}
       </div>
 
       <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
@@ -128,18 +154,45 @@ const DeleteAccountSettings = () => {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete Account</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete your account? This will permanently remove all your cloud-synced data including saved places and collections. This action cannot be undone.
+              This will permanently delete your account and all cloud-synced data. This cannot be undone.
+              {"\n\n"}Enter your password to confirm.
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          <div className="relative">
+            <Input
+              type={showPassword ? "text" : "password"}
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && password && !deleteLoading) handleDeleteAccount();
+              }}
+              disabled={deleteLoading}
+              autoComplete="current-password"
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(v => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+              tabIndex={-1}
+            >
+              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+
           <AlertDialogFooter>
             <AlertDialogCancel disabled={deleteLoading}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
+            <Button
               onClick={handleDeleteAccount}
-              disabled={deleteLoading}
+              disabled={deleteLoading || !password}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {deleteLoading ? "Deleting..." : "Delete Account"}
-            </AlertDialogAction>
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
Previously, the delete flow only signed the user out and removed Firestore data, leaving the Firebase Auth account alive — violating App Store guideline 5.1.1 (account deletion).

Changes:
- Re-authenticate with email/password before deletion (required by Firebase for sensitive operations; prevents requires-recent-login errors)
- Call deleteUser() to permanently remove the Firebase Auth account
- Add password input field with show/hide toggle to the confirmation dialog
- Improve error messages for wrong password / too-many-requests cases
- Delete button is disabled until a password is entered

https://claude.ai/code/session_016qtFsiiQtNAexdt6f6xdzv